### PR TITLE
Sector Nord AG: Bugfix: Match non case sensitive email Addresses when editing CMDB CIs. Use CustomerName function instead of CustomerSearch.

### DIFF
--- a/Kernel/Output/HTML/ITSMConfigItem/LayoutCustomer.pm
+++ b/Kernel/Output/HTML/ITSMConfigItem/LayoutCustomer.pm
@@ -192,9 +192,12 @@ sub InputCreate {
             Search => $Value,
         );
 
+        # set keys to lowercase to match non case sensitive email-adresses
+         %CustomerSearchList = map { lc $_ => $CustomerSearchList{$_} } keys %CustomerSearchList;
+
         # transform ascii to html
         $Search = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Ascii2Html(
-            Text           => $CustomerSearchList{$Value} || '',
+            Text           => $CustomerSearchList{lc $Value} || '',
             HTMLResultMode => 1,
         );
     }

--- a/Kernel/Output/HTML/ITSMConfigItem/LayoutCustomer.pm
+++ b/Kernel/Output/HTML/ITSMConfigItem/LayoutCustomer.pm
@@ -170,11 +170,11 @@ sub InputCreate {
     elsif ( $Param{Item}->{Input}->{ValueDefault} ) {
         $Value = $Param{Item}->{Input}->{ValueDefault};
     }
-    my $Class    = 'W50pc ITSMCustomerSearch';
-    my $Search   = '';
-    my $Required = $Param{Required} || '';
-    my $Invalid  = $Param{Invalid} || '';
-    my $ItemId   = $Param{ItemId} || '';
+    my $Class            = 'W50pc ITSMCustomerSearch';
+    my $CustomerUserName = '';
+    my $Required         = $Param{Required} || '';
+    my $Invalid          = $Param{Invalid} || '';
+    my $ItemId           = $Param{ItemId} || '';
 
     if ($Required) {
         $Class .= ' Validate_Required';
@@ -187,17 +187,14 @@ sub InputCreate {
     # create customer string
     if ($Value) {
 
-        # get customer data
-        my %CustomerSearchList = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerSearch(
-            Search => $Value,
+        # get customer name
+        $CustomerUserName = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerName(
+            UserLogin => $Value,
         );
 
-        # set keys to lowercase to match non case sensitive email-adresses
-         %CustomerSearchList = map { lc $_ => $CustomerSearchList{$_} } keys %CustomerSearchList;
-
         # transform ascii to html
-        $Search = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Ascii2Html(
-            Text           => $CustomerSearchList{lc $Value} || '',
+        $CustomerUserName = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Ascii2Html(
+            Text           => $CustomerUserName || '',
             HTMLResultMode => 1,
         );
     }
@@ -217,7 +214,7 @@ sub InputCreate {
         . '" id="'
         . $ItemId
         . '" value="'
-        . $Search . '"/>';
+        . $CustomerUserName . '"/>';
 
     return $String;
 }


### PR DESCRIPTION
## Proposed change

When editing a CMDB CI the current owner of the CI is displayed. The mail address of the owner must match case sensitive to the mail address of the user. If the email address of the owner of the CMDB-CI does not match the email address of any customer user email address because of different upper and lower case letters, no owner is beeing showed in AgentITSMConfigItemEdit.

The Bugfix supports non case sensitive search over the customer email addresses.

## Type of change

* Bug 

## Checklist

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
