### PR TITLE
Bug fix: adding fallback for nameless customers

### DIFF
--- a/Kernel/Output/HTML/ITSMConfigItem/LayoutCustomer.pm
+++ b/Kernel/Output/HTML/ITSMConfigItem/LayoutCustomer.pm
@@ -192,6 +192,14 @@ sub InputCreate {
             UserLogin => $Value,
         );
 
+        # fall back to pre 6.5.3 customer search if customer has no name
+        if (!$CustomerUserName) {
+            my %CustomerSearchList = $Kernel::OM->Get('Kernel::System::CustomerUser')->CustomerSearch(
+                Search => $Value,
+            );
+            $CustomerUserName = $CustomerSearchList{$Value};
+        }
+
         # transform ascii to html
         $CustomerUserName = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Ascii2Html(
             Text           => $CustomerUserName || '',


### PR DESCRIPTION
Sorry for the duplicate, had to reorder my branches...

We have a few technical accounts (from LDAP) used for stock keeping who don't have a name. before 6.5.3 these were displayed by their email address.
6.5.3 tries to show customer users by their Title, First name and Last name which is fine, however when editing a CI which has a nameless user set in a Customer field, the field is cleared and manually needs to be re-filled before saving to not lose that information.
This commit adds the old way of "resolving" the display information for these users as a fallback in case no name can be determined.